### PR TITLE
Fix Markdown header rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-##ARDUINO BRAIN LIBRARY
+## ARDUINO BRAIN LIBRARY
 
-###OVERVIEW
+### OVERVIEW
 
 Brain is an Arduino Library for parsing data from Neurosky-based EEG headsets. Tested units include the Star Wars Force Trainer and Mattel MindFlex.
 
@@ -19,31 +19,31 @@ The attention and meditation values both run from 0 - 100. Intuitively, higher n
 
 The EEG power values — delta, theta, etc... - are a heavily filtered representation of the relative activity in different brain wavelengths. These values can not be mapped directly to physical values (e.g. volts), but are still of use when considered over time or relative to each other.
 
-###Repository Rename
+### Repository Rename
 This project was formerly "Arduino-Brain-Library" on GitHub, but was renamed to just "Brain" in 2014 to play nicely with the Arduino IDE's new ""Sketch --> Import Library..." menu item.
 
-###SOFTWARE SERIAL
+### SOFTWARE SERIAL
 Past versions of this library relied on a separate branch implementing support for NewSoftSerial. Improvements to both the bundled SoftwareSerial library and the underlying class hierarchy in Arduino 1.0 has allowed a single version of the Brain library to cover both use cases. Please **do not use** the old [softserial](https://github.com/kitschpatrol/Brain/tree/softserial) branch of this library! Please see
 
 
-###EXAMPLES
+### EXAMPLES
 Three examples are provided with the library:
 
 - `BrainBlinker.ino` blinks an LED faster as your "attention" value increases.
 - `BrainSerialTest.ino` prints out a CSV of brain data over serial.
 - `BrainSoftSerialTest.ino` reads brain data over SoftwareSerial and prints a CSV over hardware serial. 
 
-###INSTALLATION
+### INSTALLATION
 There are two ways to install the library:
 
-#####Installation through the Arduino IDE
+##### Installation through the Arduino IDE
 Download the [latest release](https://github.com/kitschpatrol/Brain/releases), and then in the Arduino IDE go to ""Sketch --> Import Library..." and point the file dialogue to the Brain.zip file you just downloaded.
 
-#####Manual Installation
+##### Manual Installation
 Download the [latest release](https://github.com/kitschpatrol/Brain/releases), decompress, rename it to Brain, and drag "Brain" folder to Arduino's "libraries" folder inside your sketch folder. (On the Mac, this is ~/Documents/Arduino/libraries by default. You may need to create this folder if it does not exist.) Restart the Arduino environment.
 
 
-###FUNCTION OVERVIEW
+### FUNCTION OVERVIEW
 
 - `Brain(HardwareSerial &_brainSerial)`  
 Instantiates the brain library on a hardware serial port.
@@ -95,7 +95,7 @@ Returns the low gamma (31-40Hz) power value, associated with multi-sensory proce
 Returns the high gamma (41-50Hz) power value.
 
 
-###MINUTIAE
+### MINUTIAE
 Note that the connection to the Neurosky headset is half-duplex — it will use up the RX pin on your Arduino, but you will still be able to send data back to a PC via USB. (Although in this case you won't be able to send data to the Arduino from the PC.)
 
 You may wish to read brain data over a software serial connection instead of the Arduino's hardware serial (this frees up the hardware serial for full-duplex operation). There's a different branch of this library designed for use with NewSoftSerial: [http://github.com/kitschpatrol/Arduino-Brain-Library/tree/softserial](http://github.com/kitschpatrol/Arduino-Brain-Library/tree/softserial)
@@ -105,13 +105,13 @@ The MindFlex provides access to more brain data than the Force Trainer — in ad
 Brain data comes in quite slowly... expect a fresh packet every second or so.
 
 
-###CONTACT
+### CONTACT
 Eric Mika  
 eric@ericmika.com  
 [https://github.com/kitschpatrol](https://github.com/kitschpatrol)  
 [http://frontiernerds.com](http://frontiernerds.com)  
 
-###COLOPHON
+### COLOPHON
 Created by Eric Mika at NYU ITP in the spring of 2010.
 Updated for Arduino 1.0 in 2013.
 Revised, retested, and cleaned up in early 2014.
@@ -121,7 +121,7 @@ My thanks to Tom Igoe for his assistance during development. Thanks to my collab
 Thanks also to [Eero af Heurlin](https://github.com/rambo) for making some considered changes in his fork.
 
 
-###LICENSE
+### LICENSE
 Copyright Eric Mika, 2010-2015
 Licensed under the GNU Lesser General Public License.
 


### PR DESCRIPTION
GitHub recently updated their Markdown renderer to require a space
between the `#` characters and the title of a header. See here for
details: https://github.com/github/markup/issues/1013

This change was made by running:

    sed --in-place 's/^\(##*\)\([^# ]\)/\1 \2/' README.md